### PR TITLE
refactor(web): #172extract reusable selection presentation components

### DIFF
--- a/src/F1.Web/Components/BetStrategySelector.razor
+++ b/src/F1.Web/Components/BetStrategySelector.razor
@@ -1,0 +1,25 @@
+@using F1.Web.Models
+@using System.Linq.Expressions
+
+<h4 class="mt-4">Bet Strategy</h4>
+<InputRadioGroup Value="@Value" ValueChanged="@ValueChanged" ValueExpression="@ValueExpression">
+    <div class="form-check">
+        <InputRadio id="strategy-regular" class="form-check-input" Value="BetType.Regular" disabled="@IsReadOnly" />
+        <label class="form-check-label" for="strategy-regular">Regular</label>
+    </div>
+    <div class="form-check">
+        <InputRadio id="strategy-prequaly" class="form-check-input" Value="BetType.PreQualy" disabled="@IsReadOnly" />
+        <label class="form-check-label" for="strategy-prequaly">Pre-Qualy</label>
+    </div>
+    <div class="form-check mb-3">
+        <InputRadio id="strategy-allornothing" class="form-check-input" Value="BetType.AllOrNothing" disabled="@IsReadOnly" />
+        <label class="form-check-label" for="strategy-allornothing">All-or-Nothing</label>
+    </div>
+</InputRadioGroup>
+
+@code {
+    [Parameter] public BetType Value { get; set; }
+    [Parameter] public EventCallback<BetType> ValueChanged { get; set; }
+    [Parameter] public Expression<Func<BetType>>? ValueExpression { get; set; }
+    [Parameter] public bool IsReadOnly { get; set; }
+}

--- a/src/F1.Web/Components/BetStrategySelector.razor
+++ b/src/F1.Web/Components/BetStrategySelector.razor
@@ -1,5 +1,6 @@
 @using F1.Web.Models
 @using System.Linq.Expressions
+@using Microsoft.AspNetCore.Components
 
 <h4 class="mt-4">Bet Strategy</h4>
 <InputRadioGroup Value="@Value" ValueChanged="@ValueChanged" ValueExpression="@ValueExpression">
@@ -20,6 +21,14 @@
 @code {
     [Parameter] public BetType Value { get; set; }
     [Parameter] public EventCallback<BetType> ValueChanged { get; set; }
-    [Parameter] public Expression<Func<BetType>>? ValueExpression { get; set; }
+    [Parameter, EditorRequired] public Expression<Func<BetType>> ValueExpression { get; set; } = default!;
     [Parameter] public bool IsReadOnly { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (ValueExpression is null)
+        {
+            throw new InvalidOperationException("BetStrategySelector requires a non-null ValueExpression. Use @bind-Value or provide ValueExpression explicitly.");
+        }
+    }
 }

--- a/src/F1.Web/Components/DriverSelectionList.razor
+++ b/src/F1.Web/Components/DriverSelectionList.razor
@@ -18,8 +18,49 @@
 
 @code {
     [Parameter] public Driver[] Drivers { get; set; } = [];
-    [Parameter] public IList<string> SelectedDriverIds { get; set; } = [];
+    [Parameter] public IList<string> SelectedDriverIds { get; set; } = ["", "", "", "", ""];
     [Parameter] public bool IsReadOnly { get; set; }
+
+    protected override void OnParametersSet()
+    {
+        if (SelectedDriverIds is null)
+        {
+            SelectedDriverIds = ["", "", "", "", ""];
+            return;
+        }
+
+        if (SelectedDriverIds.Count < 5)
+        {
+            if (SelectedDriverIds is List<string> mutable)
+            {
+                while (mutable.Count < 5)
+                {
+                    mutable.Add(string.Empty);
+                }
+            }
+            else
+            {
+                var normalized = new List<string>(SelectedDriverIds);
+                while (normalized.Count < 5)
+                {
+                    normalized.Add(string.Empty);
+                }
+
+                SelectedDriverIds = normalized;
+            }
+        }
+        else if (SelectedDriverIds.Count > 5)
+        {
+            if (SelectedDriverIds is List<string> mutable)
+            {
+                mutable.RemoveRange(5, mutable.Count - 5);
+            }
+            else
+            {
+                SelectedDriverIds = SelectedDriverIds.Take(5).ToList();
+            }
+        }
+    }
 
     private void OnDriverChanged(int index, string? driverId)
     {

--- a/src/F1.Web/Components/DriverSelectionList.razor
+++ b/src/F1.Web/Components/DriverSelectionList.razor
@@ -1,0 +1,33 @@
+@using F1.Web.Models
+
+<h4>Top 5 Driver Predictions</h4>
+@for (var i = 0; i < 5; i++)
+{
+    var rank = i;
+    <div class="mb-2">
+        <label class="form-label">Position @(i + 1)</label>
+        <select id="driver-select-@(i + 1)" class="form-select" value="@SelectedDriverIds[rank]" @onchange="e => OnDriverChanged(rank, e.Value?.ToString())" disabled="@IsReadOnly">
+            <option value="">-- Select driver --</option>
+            @foreach (var driver in Drivers)
+            {
+                <option value="@driver.DriverId">@driver.FullName (@driver.DriverId)</option>
+            }
+        </select>
+    </div>
+}
+
+@code {
+    [Parameter] public Driver[] Drivers { get; set; } = [];
+    [Parameter] public IList<string> SelectedDriverIds { get; set; } = [];
+    [Parameter] public bool IsReadOnly { get; set; }
+
+    private void OnDriverChanged(int index, string? driverId)
+    {
+        if (index < 0 || index >= SelectedDriverIds.Count)
+        {
+            return;
+        }
+
+        SelectedDriverIds[index] = driverId ?? string.Empty;
+    }
+}

--- a/src/F1.Web/Components/SelectionStatusBanners.razor
+++ b/src/F1.Web/Components/SelectionStatusBanners.razor
@@ -1,0 +1,38 @@
+@using F1.Web.Models
+
+@if (!string.IsNullOrWhiteSpace(ErrorMessage))
+{
+    <div class="alert alert-danger">@ErrorMessage</div>
+}
+
+@if (!string.IsNullOrWhiteSpace(SuccessMessage))
+{
+    <div class="alert alert-success">@SuccessMessage</div>
+}
+
+@if (RaceMetadata is not null)
+{
+    <div class="alert alert-primary">
+        <h4>Race Questions</h4>
+        <p class="mb-2"><strong>H2H:</strong> @RaceMetadata.H2HQuestion</p>
+        <p class="mb-0"><strong>Bonus:</strong> @RaceMetadata.BonusQuestion</p>
+    </div>
+}
+
+@if (!string.IsNullOrWhiteSpace(CountdownText))
+{
+    <div class="alert alert-info">
+        <strong>Countdown:</strong> @CountdownText
+    </div>
+}
+
+<div class="alert alert-warning">
+    Locking for Pre-Qualy gives +50% points but prevents changes after Sunday 13:00 UTC!
+</div>
+
+@code {
+    [Parameter] public string? ErrorMessage { get; set; }
+    [Parameter] public string? SuccessMessage { get; set; }
+    [Parameter] public RaceQuestionMetadata? RaceMetadata { get; set; }
+    [Parameter] public string? CountdownText { get; set; }
+}

--- a/src/F1.Web/Pages/YasMarinaSelection.razor
+++ b/src/F1.Web/Pages/YasMarinaSelection.razor
@@ -26,7 +26,11 @@ else
     <EditForm Model="formModel" OnValidSubmit="SaveSelectionAsync">
         <DriverSelectionList Drivers="@drivers" SelectedDriverIds="@formModel.SelectedDriverIds" IsReadOnly="@isReadOnly" />
 
-        <BetStrategySelector @bind-Value="formModel.SelectedBetType" IsReadOnly="@isReadOnly" />
+        <BetStrategySelector
+            Value="@formModel.SelectedBetType"
+            ValueChanged="OnBetTypeChanged"
+            ValueExpression="@(() => formModel.SelectedBetType)"
+            IsReadOnly="@isReadOnly" />
 
         <button id="submit-selection" class="btn btn-primary" type="submit" disabled="@isReadOnly">Save Selection</button>
 
@@ -191,6 +195,12 @@ else
             HttpStatusCode.Unauthorized or HttpStatusCode.Forbidden => "You are not authorized to save this selection.",
             _ => exception.Error.Message
         };
+    }
+
+    private Task OnBetTypeChanged(BetType betType)
+    {
+        formModel.SelectedBetType = betType;
+        return Task.CompletedTask;
     }
 
     private void ApplySelectionToForm(Selection selection)

--- a/src/F1.Web/Pages/YasMarinaSelection.razor
+++ b/src/F1.Web/Pages/YasMarinaSelection.razor
@@ -11,71 +11,22 @@
 
 <h1>Yas Marina GP 2025 Selection</h1>
 
-@if (!string.IsNullOrWhiteSpace(errorMessage))
-{
-    <div class="alert alert-danger">@errorMessage</div>
-}
-
-@if (!string.IsNullOrWhiteSpace(successMessage))
-{
-    <div class="alert alert-success">@successMessage</div>
-}
-
 @if (drivers is null || raceConfig is null)
 {
     <p><em>Loading...</em></p>
 }
 else
 {
-    @if (raceMetadata is not null)
-    {
-        <div class="alert alert-primary">
-            <h4>Race Questions</h4>
-            <p class="mb-2"><strong>H2H:</strong> @raceMetadata.H2HQuestion</p>
-            <p class="mb-0"><strong>Bonus:</strong> @raceMetadata.BonusQuestion</p>
-        </div>
-    }
-
-    <div class="alert alert-info">
-        <strong>Countdown:</strong> @GetCountdownText()
-    </div>
-
-    <div class="alert alert-warning">
-        Locking for Pre-Qualy gives +50% points but prevents changes after Sunday 13:00 UTC!
-    </div>
+    <SelectionStatusBanners
+        ErrorMessage="@errorMessage"
+        SuccessMessage="@successMessage"
+        RaceMetadata="@raceMetadata"
+        CountdownText="@GetCountdownText()" />
 
     <EditForm Model="formModel" OnValidSubmit="SaveSelectionAsync">
-        <h4>Top 5 Driver Predictions</h4>
-        @for (var i = 0; i < 5; i++)
-        {
-            var rank = i;
-            <div class="mb-2">
-                <label class="form-label">Position @(i + 1)</label>
-                <select id="driver-select-@(i + 1)" class="form-select" value="@formModel.SelectedDriverIds[rank]" @onchange="e => OnDriverChanged(rank, e.Value?.ToString())" disabled="@isReadOnly">
-                    <option value="">-- Select driver --</option>
-                    @foreach (var driver in drivers)
-                    {
-                        <option value="@driver.DriverId">@driver.FullName (@driver.DriverId)</option>
-                    }
-                </select>
-            </div>
-        }
+        <DriverSelectionList Drivers="@drivers" SelectedDriverIds="@formModel.SelectedDriverIds" IsReadOnly="@isReadOnly" />
 
-        <h4 class="mt-4">Bet Strategy</h4>
-        <InputRadioGroup @bind-Value="formModel.SelectedBetType">
-            <div class="form-check">
-                <InputRadio id="strategy-regular" class="form-check-input" Value="BetType.Regular" disabled="@isReadOnly" />
-                <label class="form-check-label" for="strategy-regular">Regular</label>
-            </div>
-            <div class="form-check">
-                <InputRadio id="strategy-prequaly" class="form-check-input" Value="BetType.PreQualy" disabled="@isReadOnly" />
-                <label class="form-check-label" for="strategy-prequaly">Pre-Qualy</label>
-            </div>
-            <div class="form-check mb-3">
-                <InputRadio id="strategy-allornothing" class="form-check-input" Value="BetType.AllOrNothing" disabled="@isReadOnly" />
-                <label class="form-check-label" for="strategy-allornothing">All-or-Nothing</label>
-            </div>
-        </InputRadioGroup>
+        <BetStrategySelector @bind-Value="formModel.SelectedBetType" IsReadOnly="@isReadOnly" />
 
         <button id="submit-selection" class="btn btn-primary" type="submit" disabled="@isReadOnly">Save Selection</button>
 
@@ -263,11 +214,6 @@ else
         }
 
         isReadOnly = selection.IsLocked;
-    }
-
-    private void OnDriverChanged(int index, string? driverId)
-    {
-        formModel.SelectedDriverIds[index] = driverId ?? string.Empty;
     }
 
     private string GetCountdownText()

--- a/src/F1.Web/Services/Api/ApiResponseParser.cs
+++ b/src/F1.Web/Services/Api/ApiResponseParser.cs
@@ -6,6 +6,9 @@ namespace F1.Web.Services.Api;
 
 public static class ApiResponseParser
 {
+    /// <summary>
+    /// Validates the HTTP status code and throws an <see cref="ApiServiceException"/> populated from the response body on failure.
+    /// </summary>
     public static async Task EnsureSuccessAsync(HttpResponseMessage response, string operation, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(response);
@@ -18,6 +21,9 @@ public static class ApiResponseParser
         throw await CreateErrorAsync(response, operation, cancellationToken);
     }
 
+    /// <summary>
+    /// Reads a successful JSON response where a payload is required. Null, malformed JSON, and unsupported content types throw <see cref="ApiServiceException"/>.
+    /// </summary>
     public static async Task<T> ReadRequiredJsonAsync<T>(HttpResponseMessage response, string operation, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(response);
@@ -49,7 +55,11 @@ public static class ApiResponseParser
         }
     }
 
-    public static async Task<T> ReadJsonOrDefaultAsync<T>(HttpResponseMessage response, T fallbackValue, string operation, CancellationToken cancellationToken = default)
+    /// <summary>
+    /// Reads a successful JSON response where a null payload is allowed and should be replaced with <paramref name="fallbackValue"/>.
+    /// Non-success status codes, malformed JSON, and unsupported content types still throw <see cref="ApiServiceException"/>.
+    /// </summary>
+    public static async Task<T> ReadOptionalJsonAsync<T>(HttpResponseMessage response, T fallbackValue, string operation, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(response);
 

--- a/src/F1.Web/Services/Api/DriversApiService.cs
+++ b/src/F1.Web/Services/Api/DriversApiService.cs
@@ -14,6 +14,6 @@ public sealed class DriversApiService(HttpClient httpClient) : IDriversApiServic
             return Array.Empty<Driver>();
         }
 
-        return await ApiResponseParser.ReadJsonOrDefaultAsync(response, Array.Empty<Driver>(), "Loading drivers", cancellationToken);
+        return await ApiResponseParser.ReadOptionalJsonAsync(response, Array.Empty<Driver>(), "Loading drivers", cancellationToken);
     }
 }

--- a/src/F1.Web/Services/Api/RaceMetadataApiService.cs
+++ b/src/F1.Web/Services/Api/RaceMetadataApiService.cs
@@ -15,6 +15,6 @@ public sealed class RaceMetadataApiService(HttpClient httpClient) : IRaceMetadat
             return null;
         }
 
-        return await ApiResponseParser.ReadJsonOrDefaultAsync<RaceQuestionMetadata?>(response, null, "Loading race metadata", cancellationToken);
+        return await ApiResponseParser.ReadOptionalJsonAsync<RaceQuestionMetadata?>(response, null, "Loading race metadata", cancellationToken);
     }
 }

--- a/src/F1.Web/Services/Api/SelectionApiService.cs
+++ b/src/F1.Web/Services/Api/SelectionApiService.cs
@@ -24,13 +24,13 @@ public sealed class SelectionApiService(HttpClient httpClient) : ISelectionApiSe
             return null;
         }
 
-        return await ApiResponseParser.ReadJsonOrDefaultAsync<Selection?>(response, null, "Loading my race selection", cancellationToken);
+        return await ApiResponseParser.ReadOptionalJsonAsync<Selection?>(response, null, "Loading my race selection", cancellationToken);
     }
 
     public async Task<CurrentSelectionItem[]> GetCurrentAsync(CancellationToken cancellationToken = default)
     {
         using var response = await httpClient.GetAsync("selections/current", cancellationToken);
-        return await ApiResponseParser.ReadJsonOrDefaultAsync(response, Array.Empty<CurrentSelectionItem>(), "Loading current selections", cancellationToken);
+        return await ApiResponseParser.ReadOptionalJsonAsync(response, Array.Empty<CurrentSelectionItem>(), "Loading current selections", cancellationToken);
     }
 
     public async Task<Selection> SaveMineAsync(string raceId, SelectionSubmission submission, CancellationToken cancellationToken = default)

--- a/src/F1.Web/_Imports.razor
+++ b/src/F1.Web/_Imports.razor
@@ -10,6 +10,7 @@
 @using Microsoft.AspNetCore.Components.WebAssembly.Http
 @using Microsoft.JSInterop
 @using F1.Web
+@using F1.Web.Components
 @using F1.Web.Layout
 @using F1.Web.Services
 @using F1.Web.Pages

--- a/tests/F1.Web.Tests/Components/BetStrategySelectorTests.cs
+++ b/tests/F1.Web.Tests/Components/BetStrategySelectorTests.cs
@@ -1,0 +1,66 @@
+using System.Linq.Expressions;
+using F1.Web.Components;
+using F1.Web.Models;
+using Microsoft.AspNetCore.Components;
+
+namespace F1.Web.Tests.Components;
+
+public class BetStrategySelectorTests : BunitContext
+{
+    [Fact]
+    public void BetStrategySelector_ShouldRenderAllOptions_AndReflectCurrentValue()
+    {
+        var currentValue = BetType.PreQualy;
+        Expression<Func<BetType>> valueExpression = () => currentValue;
+
+        var cut = Render<BetStrategySelector>(parameters => parameters
+            .Add(p => p.Value, currentValue)
+            .Add(p => p.ValueExpression, valueExpression)
+            .Add(p => p.ValueChanged, EventCallback.Factory.Create<BetType>(new object(), _ => { }))
+            .Add(p => p.IsReadOnly, false));
+
+        Assert.Contains("Regular", cut.Markup);
+        Assert.Contains("Pre-Qualy", cut.Markup);
+        Assert.Contains("All-or-Nothing", cut.Markup);
+        Assert.True(cut.Find("#strategy-prequaly").HasAttribute("checked"));
+    }
+
+    [Fact]
+    public void BetStrategySelector_ShouldDisableAllOptions_WhenReadOnly()
+    {
+        var currentValue = BetType.Regular;
+        Expression<Func<BetType>> valueExpression = () => currentValue;
+
+        var cut = Render<BetStrategySelector>(parameters => parameters
+            .Add(p => p.Value, currentValue)
+            .Add(p => p.ValueExpression, valueExpression)
+            .Add(p => p.ValueChanged, EventCallback.Factory.Create<BetType>(new object(), _ => { }))
+            .Add(p => p.IsReadOnly, true));
+
+        Assert.True(cut.FindAll("input[type='radio']").All(element => element.HasAttribute("disabled")));
+    }
+
+    [Fact]
+    public void BetStrategySelector_ShouldUpdateCheckedOption_WhenValueChanges()
+    {
+        var initialValue = BetType.Regular;
+        Expression<Func<BetType>> initialExpression = () => initialValue;
+        var initial = Render<BetStrategySelector>(parameters => parameters
+            .Add(p => p.Value, initialValue)
+            .Add(p => p.ValueExpression, initialExpression)
+            .Add(p => p.ValueChanged, EventCallback.Factory.Create<BetType>(new object(), _ => { }))
+            .Add(p => p.IsReadOnly, false));
+
+        Assert.True(initial.Find("#strategy-regular").HasAttribute("checked"));
+
+        var updatedValue = BetType.AllOrNothing;
+        Expression<Func<BetType>> updatedExpression = () => updatedValue;
+        var updated = Render<BetStrategySelector>(parameters => parameters
+            .Add(p => p.Value, updatedValue)
+            .Add(p => p.ValueExpression, updatedExpression)
+            .Add(p => p.ValueChanged, EventCallback.Factory.Create<BetType>(new object(), _ => { }))
+            .Add(p => p.IsReadOnly, false));
+
+        Assert.True(updated.Find("#strategy-allornothing").HasAttribute("checked"));
+    }
+}

--- a/tests/F1.Web.Tests/Components/DriverSelectionListTests.cs
+++ b/tests/F1.Web.Tests/Components/DriverSelectionListTests.cs
@@ -1,0 +1,62 @@
+using F1.Web.Components;
+using F1.Web.Models;
+
+namespace F1.Web.Tests.Components;
+
+public class DriverSelectionListTests : BunitContext
+{
+    [Fact]
+    public void DriverSelectionList_ShouldRenderFiveSelectors_WithDriverOptions()
+    {
+        var selectedDriverIds = new List<string> { "", "", "", "", "" };
+        var drivers = new[]
+        {
+            new Driver { DriverId = "norris", FullName = "Lando Norris" },
+            new Driver { DriverId = "leclerc", FullName = "Charles Leclerc" }
+        };
+
+        var cut = Render<DriverSelectionList>(parameters => parameters
+            .Add(p => p.Drivers, drivers)
+            .Add(p => p.SelectedDriverIds, selectedDriverIds)
+            .Add(p => p.IsReadOnly, false));
+
+        Assert.Equal(5, cut.FindAll("select").Count);
+        Assert.Contains("Lando Norris (norris)", cut.Markup);
+        Assert.Contains("Charles Leclerc (leclerc)", cut.Markup);
+    }
+
+    [Fact]
+    public void DriverSelectionList_ShouldUpdateSelectedDriverIds_WhenSelectionChanges()
+    {
+        var selectedDriverIds = new List<string> { "", "", "", "", "" };
+        var drivers = new[]
+        {
+            new Driver { DriverId = "norris", FullName = "Lando Norris" },
+            new Driver { DriverId = "leclerc", FullName = "Charles Leclerc" }
+        };
+
+        var cut = Render<DriverSelectionList>(parameters => parameters
+            .Add(p => p.Drivers, drivers)
+            .Add(p => p.SelectedDriverIds, selectedDriverIds)
+            .Add(p => p.IsReadOnly, false));
+
+        cut.Find("#driver-select-1").Change("norris");
+        cut.Find("#driver-select-2").Change("leclerc");
+
+        Assert.Equal("norris", selectedDriverIds[0]);
+        Assert.Equal("leclerc", selectedDriverIds[1]);
+    }
+
+    [Fact]
+    public void DriverSelectionList_ShouldDisableSelectors_WhenReadOnly()
+    {
+        var selectedDriverIds = new List<string> { "", "", "", "", "" };
+
+        var cut = Render<DriverSelectionList>(parameters => parameters
+            .Add(p => p.Drivers, Array.Empty<Driver>())
+            .Add(p => p.SelectedDriverIds, selectedDriverIds)
+            .Add(p => p.IsReadOnly, true));
+
+        Assert.True(cut.FindAll("select").All(element => element.HasAttribute("disabled")));
+    }
+}

--- a/tests/F1.Web.Tests/Components/DriverSelectionListTests.cs
+++ b/tests/F1.Web.Tests/Components/DriverSelectionListTests.cs
@@ -6,6 +6,17 @@ namespace F1.Web.Tests.Components;
 public class DriverSelectionListTests : BunitContext
 {
     [Fact]
+    public void DriverSelectionList_ShouldRender_WhenSelectedDriverIdsIsNotProvided()
+    {
+        var cut = Render<DriverSelectionList>(parameters => parameters
+            .Add(p => p.Drivers, Array.Empty<Driver>())
+            .Add(p => p.IsReadOnly, false));
+
+        Assert.Equal(5, cut.FindAll("select").Count);
+        Assert.Equal(5, cut.Instance.SelectedDriverIds.Count);
+    }
+
+    [Fact]
     public void DriverSelectionList_ShouldRenderFiveSelectors_WithDriverOptions()
     {
         var selectedDriverIds = new List<string> { "", "", "", "", "" };
@@ -58,5 +69,33 @@ public class DriverSelectionListTests : BunitContext
             .Add(p => p.IsReadOnly, true));
 
         Assert.True(cut.FindAll("select").All(element => element.HasAttribute("disabled")));
+    }
+
+    [Fact]
+    public void DriverSelectionList_ShouldPadSelectedDriverIds_WhenShortListProvided()
+    {
+        var selectedDriverIds = new List<string> { "norris", "leclerc" };
+
+        var cut = Render<DriverSelectionList>(parameters => parameters
+            .Add(p => p.Drivers, Array.Empty<Driver>())
+            .Add(p => p.SelectedDriverIds, selectedDriverIds)
+            .Add(p => p.IsReadOnly, false));
+
+        Assert.Equal(5, cut.Instance.SelectedDriverIds.Count);
+        Assert.Equal("norris", cut.Instance.SelectedDriverIds[0]);
+        Assert.Equal("leclerc", cut.Instance.SelectedDriverIds[1]);
+        Assert.Equal(string.Empty, cut.Instance.SelectedDriverIds[2]);
+    }
+
+    [Fact]
+    public void DriverSelectionList_ShouldNormalizeSelectedDriverIds_WhenNullProvided()
+    {
+        var cut = Render<DriverSelectionList>(parameters => parameters
+            .Add(p => p.Drivers, Array.Empty<Driver>())
+            .Add(p => p.SelectedDriverIds, (IList<string>)null!)
+            .Add(p => p.IsReadOnly, false));
+
+        Assert.Equal(5, cut.FindAll("select").Count);
+        Assert.Equal(5, cut.Instance.SelectedDriverIds.Count);
     }
 }

--- a/tests/F1.Web.Tests/Components/SelectionStatusBannersTests.cs
+++ b/tests/F1.Web.Tests/Components/SelectionStatusBannersTests.cs
@@ -1,0 +1,42 @@
+using F1.Web.Components;
+using F1.Web.Models;
+
+namespace F1.Web.Tests.Components;
+
+public class SelectionStatusBannersTests : BunitContext
+{
+    [Fact]
+    public void SelectionStatusBanners_ShouldRenderAllConfiguredSections()
+    {
+        var cut = Render<SelectionStatusBanners>(parameters => parameters
+            .Add(p => p.ErrorMessage, "Something went wrong")
+            .Add(p => p.SuccessMessage, "Saved")
+            .Add(p => p.CountdownText, "Pre-Qualy lock in 1d 2h 3m 4s (UTC).")
+            .Add(p => p.RaceMetadata, new RaceQuestionMetadata
+            {
+                H2HQuestion = "Who finishes higher?",
+                BonusQuestion = "How many DNFs?"
+            }));
+
+        Assert.Contains("Something went wrong", cut.Markup);
+        Assert.Contains("Saved", cut.Markup);
+        Assert.Contains("Race Questions", cut.Markup);
+        Assert.Contains("Who finishes higher?", cut.Markup);
+        Assert.Contains("How many DNFs?", cut.Markup);
+        Assert.Contains("Countdown:", cut.Markup);
+        Assert.Contains("Locking for Pre-Qualy gives +50% points", cut.Markup);
+    }
+
+    [Fact]
+    public void SelectionStatusBanners_ShouldHideOptionalSections_WhenValuesMissing()
+    {
+        var cut = Render<SelectionStatusBanners>(parameters => parameters
+            .Add(p => p.CountdownText, string.Empty));
+
+        Assert.DoesNotContain("alert-danger", cut.Markup);
+        Assert.DoesNotContain("alert-success", cut.Markup);
+        Assert.DoesNotContain("Race Questions", cut.Markup);
+        Assert.DoesNotContain("Countdown:", cut.Markup);
+        Assert.Contains("alert-warning", cut.Markup);
+    }
+}

--- a/tests/F1.Web.Tests/Services/Api/ApiResponseParserTests.cs
+++ b/tests/F1.Web.Tests/Services/Api/ApiResponseParserTests.cs
@@ -49,7 +49,7 @@ public class ApiResponseParserTests
     }
 
     [Fact]
-    public async Task ReadJsonOrDefaultAsync_WhenPayloadIsNull_ReturnsFallback()
+    public async Task ReadOptionalJsonAsync_WhenPayloadIsNull_ReturnsFallback()
     {
         using var response = new HttpResponseMessage(HttpStatusCode.OK)
         {
@@ -57,7 +57,7 @@ public class ApiResponseParserTests
         };
 
         var fallback = Array.Empty<Driver>();
-        var result = await ApiResponseParser.ReadJsonOrDefaultAsync(response, fallback, "Loading drivers");
+        var result = await ApiResponseParser.ReadOptionalJsonAsync(response, fallback, "Loading drivers");
 
         Assert.Same(fallback, result);
     }


### PR DESCRIPTION
- extract status banners, driver selector list, and bet strategy selector
- simplify YasMarinaSelection by delegating presentational markup
- add focused component tests for extracted UI blocks
- keep existing page behavior and orchestration intact