### PR TITLE
#239 persist Jolpica circuitId on migration race-round mappings for a…

### DIFF
--- a/src/F1.DataSyncWorker/Models/JolpicaResponses.cs
+++ b/src/F1.DataSyncWorker/Models/JolpicaResponses.cs
@@ -82,6 +82,9 @@ public sealed class JolpicaRaceDto
 
 public sealed class JolpicaCircuitDto
 {
+    [JsonPropertyName("circuitId")]
+    public string? CircuitId { get; set; }
+
     [JsonPropertyName("circuitName")]
     public string? CircuitName { get; set; }
 }

--- a/src/F1.DataSyncWorker/Services/MigrationImportOrchestrator.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationImportOrchestrator.cs
@@ -86,9 +86,11 @@ public sealed class MigrationImportOrchestrator : IMigrationImportOrchestrator
             }
 
             var mappingResult = (SnapshotCount: 0, MappingCount: 0, WarningCount: 0);
+            var selectionRaceCodesRewritten = 0;
             if (!run.IsDryRun)
             {
                 mappingResult = await _raceRoundMapper.MapAndPersistAsync(run.RunId, cancellationToken);
+                selectionRaceCodesRewritten = await RewriteSelectionRaceCodesToMappedCircuitIdsAsync(run.RunId, cancellationToken);
             }
             else
             {
@@ -104,13 +106,14 @@ public sealed class MigrationImportOrchestrator : IMigrationImportOrchestrator
             await _runService.CompleteRunAsync(run.RunId, totalRows, cancellationToken);
 
             _logger.LogInformation(
-                "Migration import run completed. RunId={RunId}, RowsStaged={RowsStaged}, RaceSelectionsParsed={RaceSelectionsParsed}, JolpicaSnapshots={JolpicaSnapshots}, RoundMappings={RoundMappings}, MappingWarnings={MappingWarnings}, ScoredPicks={ScoredPicks}, CalculatedPoints={CalculatedPoints}, LegacyPickScores={LegacyPickScores}, ImportedTotals={ImportedTotals}, CalculatedTotals={CalculatedTotals}, PickDiffs={PickDiffs}, RaceDiffs={RaceDiffs}, ParticipantDeltaSummaries={ParticipantDeltaSummaries}, ReasonSummaries={ReasonSummaries}, NetDelta={NetDelta}, Checksum={Checksum}",
+                "Migration import run completed. RunId={RunId}, RowsStaged={RowsStaged}, RaceSelectionsParsed={RaceSelectionsParsed}, JolpicaSnapshots={JolpicaSnapshots}, RoundMappings={RoundMappings}, MappingWarnings={MappingWarnings}, SelectionRaceCodesRewritten={SelectionRaceCodesRewritten}, ScoredPicks={ScoredPicks}, CalculatedPoints={CalculatedPoints}, LegacyPickScores={LegacyPickScores}, ImportedTotals={ImportedTotals}, CalculatedTotals={CalculatedTotals}, PickDiffs={PickDiffs}, RaceDiffs={RaceDiffs}, ParticipantDeltaSummaries={ParticipantDeltaSummaries}, ReasonSummaries={ReasonSummaries}, NetDelta={NetDelta}, Checksum={Checksum}",
                 run.RunId,
                 totalRows,
                 parseResult.SelectionCount,
                 mappingResult.SnapshotCount,
                 mappingResult.MappingCount,
                 mappingResult.WarningCount,
+                selectionRaceCodesRewritten,
                 scoreResult.ScoredPickCount,
                 scoreResult.TotalPoints,
                 legacyResult.LegacyPickScoreCount,
@@ -180,5 +183,52 @@ public sealed class MigrationImportOrchestrator : IMigrationImportOrchestrator
         }
 
         return Path.GetFullPath(sourceFilePath, Directory.GetCurrentDirectory());
+    }
+
+    private async Task<int> RewriteSelectionRaceCodesToMappedCircuitIdsAsync(Guid runId, CancellationToken cancellationToken)
+    {
+        await using var dbContext = await _dbContextFactory.CreateDbContextAsync(cancellationToken);
+
+        var mappings = await dbContext.MigrationImportRaceRoundMappings
+            .Where(x => x.ImportRunId == runId && !string.IsNullOrWhiteSpace(x.MappedCircuitId))
+            .OrderBy(x => x.SourceRowNumber)
+            .Select(x => new { x.SourceRowNumber, x.MappedCircuitId })
+            .ToListAsync(cancellationToken);
+
+        if (mappings.Count == 0)
+        {
+            return 0;
+        }
+
+        var rewritten = 0;
+        for (var index = 0; index < mappings.Count; index++)
+        {
+            var startRow = mappings[index].SourceRowNumber;
+            var endRow = index + 1 < mappings.Count
+                ? mappings[index + 1].SourceRowNumber - 1
+                : int.MaxValue;
+            var mappedCircuitId = mappings[index].MappedCircuitId!;
+
+            var selections = await dbContext.MigrationImportRaceSelections
+                .Where(x =>
+                    x.ImportRunId == runId &&
+                    x.RowNumber >= startRow &&
+                    x.RowNumber <= endRow &&
+                    x.RaceCode != mappedCircuitId)
+                .ToListAsync(cancellationToken);
+
+            foreach (var selection in selections)
+            {
+                selection.RaceCode = mappedCircuitId;
+                rewritten++;
+            }
+        }
+
+        if (rewritten > 0)
+        {
+            await dbContext.SaveChangesAsync(cancellationToken);
+        }
+
+        return rewritten;
     }
 }

--- a/src/F1.DataSyncWorker/Services/MigrationImportOrchestrator.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationImportOrchestrator.cs
@@ -209,24 +209,17 @@ public sealed class MigrationImportOrchestrator : IMigrationImportOrchestrator
                 : int.MaxValue;
             var mappedCircuitId = mappings[index].MappedCircuitId!;
 
-            var selections = await dbContext.MigrationImportRaceSelections
+            var updated = await dbContext.MigrationImportRaceSelections
                 .Where(x =>
                     x.ImportRunId == runId &&
                     x.RowNumber >= startRow &&
                     x.RowNumber <= endRow &&
                     x.RaceCode != mappedCircuitId)
-                .ToListAsync(cancellationToken);
+                .ExecuteUpdateAsync(
+                    setters => setters.SetProperty(selection => selection.RaceCode, mappedCircuitId),
+                    cancellationToken);
 
-            foreach (var selection in selections)
-            {
-                selection.RaceCode = mappedCircuitId;
-                rewritten++;
-            }
-        }
-
-        if (rewritten > 0)
-        {
-            await dbContext.SaveChangesAsync(cancellationToken);
+            rewritten += updated;
         }
 
         return rewritten;

--- a/src/F1.DataSyncWorker/Services/MigrationLegacyScoreImporter.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationLegacyScoreImporter.cs
@@ -12,69 +12,6 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
     private const string SectionTypeHeader = "Header";
     private const string SectionTypeRacePoints = "RacePoints";
     private const string SectionTypeTotalsMeta = "TotalsMeta";
-    private static readonly Dictionary<string, string> RaceCodeAliasDictionary = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["AUS"] = "albert_park",
-        ["AUSTRALIA"] = "albert_park",
-        ["ALBERT PARK"] = "albert_park",
-        ["CHN"] = "shanghai",
-        ["CHINA"] = "shanghai",
-        ["SHANGHAI"] = "shanghai",
-        ["JPN"] = "suzuka",
-        ["JAPAN"] = "suzuka",
-        ["SUZUKA"] = "suzuka",
-        ["BAH"] = "bahrain",
-        ["BAHRAIN"] = "bahrain",
-        ["SAR"] = "jeddah",
-        ["SAUDI"] = "jeddah",
-        ["JEDDAH"] = "jeddah",
-        ["MIA"] = "miami",
-        ["MIAMI"] = "miami",
-        ["IMO"] = "imola",
-        ["IMOLA"] = "imola",
-        ["MON"] = "monaco",
-        ["MONACO"] = "monaco",
-        ["MONZA"] = "monza",
-        ["MNZ"] = "monza",
-        ["ITA"] = "monza",
-        ["ITALY"] = "monza",
-        ["BAR"] = "catalunya",
-        ["ESP"] = "catalunya",
-        ["SPAIN"] = "catalunya",
-        ["CAN"] = "villeneuve",
-        ["CANADA"] = "villeneuve",
-        ["AUSTRIA"] = "red_bull_ring",
-        ["AUT"] = "red_bull_ring",
-        ["RED BULL RING"] = "red_bull_ring",
-        ["GBR"] = "silverstone",
-        ["BRITAIN"] = "silverstone",
-        ["SILVERSTONE"] = "silverstone",
-        ["SPA"] = "spa",
-        ["BEL"] = "spa",
-        ["BELGIUM"] = "spa",
-        ["HUN"] = "hungaroring",
-        ["HUNGARY"] = "hungaroring",
-        ["NED"] = "zandvoort",
-        ["NETHERLANDS"] = "zandvoort",
-        ["BAK"] = "baku",
-        ["AZE"] = "baku",
-        ["AZERBAIJAN"] = "baku",
-        ["SIN"] = "marina_bay",
-        ["SINGAPORE"] = "marina_bay",
-        ["COTA"] = "americas",
-        ["USA"] = "americas",
-        ["UNITED STATES"] = "americas",
-        ["MEX"] = "rodriguez",
-        ["MEXICO"] = "rodriguez",
-        ["BRA"] = "interlagos",
-        ["BRAZIL"] = "interlagos",
-        ["LAS"] = "las_vegas",
-        ["VEGAS"] = "las_vegas",
-        ["QAT"] = "losail",
-        ["QATAR"] = "losail",
-        ["ABD"] = "yas_marina",
-        ["ABU DHABI"] = "yas_marina"
-    };
 
     private readonly IDbContextFactory<F1DbContext> _dbContextFactory;
 
@@ -304,21 +241,10 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
             return false;
         }
 
-        raceCode = NormalizeRaceCode(match.Groups[1].Value);
+        raceCode = RaceCodeNormalizer.NormalizeRaceCode(match.Groups[1].Value);
         pickType = match.Groups[2].Value.ToUpperInvariant();
         currentRaceCode = raceCode;
         return true;
-    }
-
-    private static string NormalizeRaceCode(string raceToken)
-    {
-        var upper = raceToken.Trim().ToUpperInvariant();
-        if (RaceCodeAliasDictionary.TryGetValue(upper, out var mapped))
-        {
-            return mapped;
-        }
-
-        return upper.Length <= 3 ? upper : upper[..3];
     }
 
     private static List<string> ParseCsvLine(string line)
@@ -358,6 +284,6 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
         return fields;
     }
 
-    [GeneratedRegex("^([A-Za-z]{3,})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    [GeneratedRegex("^([A-Za-z][A-Za-z\\s]{2,})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex RaceLabelRegex();
 }

--- a/src/F1.DataSyncWorker/Services/MigrationLegacyScoreImporter.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationLegacyScoreImporter.cs
@@ -12,6 +12,69 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
     private const string SectionTypeHeader = "Header";
     private const string SectionTypeRacePoints = "RacePoints";
     private const string SectionTypeTotalsMeta = "TotalsMeta";
+    private static readonly Dictionary<string, string> RaceCodeAliasDictionary = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["AUS"] = "albert_park",
+        ["AUSTRALIA"] = "albert_park",
+        ["ALBERT PARK"] = "albert_park",
+        ["CHN"] = "shanghai",
+        ["CHINA"] = "shanghai",
+        ["SHANGHAI"] = "shanghai",
+        ["JPN"] = "suzuka",
+        ["JAPAN"] = "suzuka",
+        ["SUZUKA"] = "suzuka",
+        ["BAH"] = "bahrain",
+        ["BAHRAIN"] = "bahrain",
+        ["SAR"] = "jeddah",
+        ["SAUDI"] = "jeddah",
+        ["JEDDAH"] = "jeddah",
+        ["MIA"] = "miami",
+        ["MIAMI"] = "miami",
+        ["IMO"] = "imola",
+        ["IMOLA"] = "imola",
+        ["MON"] = "monaco",
+        ["MONACO"] = "monaco",
+        ["MONZA"] = "monza",
+        ["MNZ"] = "monza",
+        ["ITA"] = "monza",
+        ["ITALY"] = "monza",
+        ["BAR"] = "catalunya",
+        ["ESP"] = "catalunya",
+        ["SPAIN"] = "catalunya",
+        ["CAN"] = "villeneuve",
+        ["CANADA"] = "villeneuve",
+        ["AUSTRIA"] = "red_bull_ring",
+        ["AUT"] = "red_bull_ring",
+        ["RED BULL RING"] = "red_bull_ring",
+        ["GBR"] = "silverstone",
+        ["BRITAIN"] = "silverstone",
+        ["SILVERSTONE"] = "silverstone",
+        ["SPA"] = "spa",
+        ["BEL"] = "spa",
+        ["BELGIUM"] = "spa",
+        ["HUN"] = "hungaroring",
+        ["HUNGARY"] = "hungaroring",
+        ["NED"] = "zandvoort",
+        ["NETHERLANDS"] = "zandvoort",
+        ["BAK"] = "baku",
+        ["AZE"] = "baku",
+        ["AZERBAIJAN"] = "baku",
+        ["SIN"] = "marina_bay",
+        ["SINGAPORE"] = "marina_bay",
+        ["COTA"] = "americas",
+        ["USA"] = "americas",
+        ["UNITED STATES"] = "americas",
+        ["MEX"] = "rodriguez",
+        ["MEXICO"] = "rodriguez",
+        ["BRA"] = "interlagos",
+        ["BRAZIL"] = "interlagos",
+        ["LAS"] = "las_vegas",
+        ["VEGAS"] = "las_vegas",
+        ["QAT"] = "losail",
+        ["QATAR"] = "losail",
+        ["ABD"] = "yas_marina",
+        ["ABU DHABI"] = "yas_marina"
+    };
 
     private readonly IDbContextFactory<F1DbContext> _dbContextFactory;
 
@@ -32,6 +95,11 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
 
         var headerRow = stagedRows.FirstOrDefault(x => string.Equals(x.SectionType, SectionTypeHeader, StringComparison.Ordinal));
         var participants = ResolveParticipants(headerRow?.RawPayload);
+        var mappedCircuitBySequence = await dbContext.MigrationImportRaceRoundMappings
+            .Where(x => x.ImportRunId == runId)
+            .OrderBy(x => x.RaceSequence)
+            .Select(x => new { x.RaceSequence, x.MappedCircuitId })
+            .ToDictionaryAsync(x => x.RaceSequence, x => x.MappedCircuitId, cancellationToken);
 
         dbContext.MigrationImportLegacyPickScores.RemoveRange(
             dbContext.MigrationImportLegacyPickScores.Where(x => x.ImportRunId == runId));
@@ -48,6 +116,7 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
 
         var legacyPickScores = new List<MigrationImportLegacyPickScoreEntity>();
         string? currentRaceCode = null;
+        var raceSequence = 0;
 
         foreach (var row in stagedRows.Where(x => string.Equals(x.SectionType, SectionTypeRacePoints, StringComparison.Ordinal)))
         {
@@ -61,6 +130,15 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
             {
                 continue;
             }
+
+            if (string.Equals(pickType, "1", StringComparison.OrdinalIgnoreCase))
+            {
+                raceSequence++;
+            }
+
+            var mappedRaceCode = mappedCircuitBySequence.TryGetValue(raceSequence, out var mappedCircuitId) && !string.IsNullOrWhiteSpace(mappedCircuitId)
+                ? mappedCircuitId
+                : raceCode;
 
             var participantValues = columns.Skip(1).Take(participants.Count).ToArray();
             for (var index = 0; index < participants.Count; index++)
@@ -76,7 +154,7 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
                 {
                     ImportRunId = runId,
                     RowNumber = row.RowNumber,
-                    RaceCode = raceCode,
+                    RaceCode = mappedRaceCode,
                     PickType = pickType,
                     Subject = participants[index],
                     RawLegacyPoints = raw,
@@ -175,7 +253,11 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
         return participants;
     }
 
-    private static bool TryResolveRace(string label, ref string? currentRaceCode, out string raceCode, out string pickType)
+    private static bool TryResolveRace(
+        string label,
+        ref string? currentRaceCode,
+        out string raceCode,
+        out string pickType)
     {
         raceCode = string.Empty;
         pickType = string.Empty;
@@ -222,10 +304,21 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
             return false;
         }
 
-        raceCode = match.Groups[1].Value.ToUpperInvariant();
+        raceCode = NormalizeRaceCode(match.Groups[1].Value);
         pickType = match.Groups[2].Value.ToUpperInvariant();
         currentRaceCode = raceCode;
         return true;
+    }
+
+    private static string NormalizeRaceCode(string raceToken)
+    {
+        var upper = raceToken.Trim().ToUpperInvariant();
+        if (RaceCodeAliasDictionary.TryGetValue(upper, out var mapped))
+        {
+            return mapped;
+        }
+
+        return upper.Length <= 3 ? upper : upper[..3];
     }
 
     private static List<string> ParseCsvLine(string line)
@@ -265,6 +358,6 @@ public sealed partial class MigrationLegacyScoreImporter : IMigrationLegacyScore
         return fields;
     }
 
-    [GeneratedRegex("^([A-Za-z]{3})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    [GeneratedRegex("^([A-Za-z]{3,})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex RaceLabelRegex();
 }

--- a/src/F1.DataSyncWorker/Services/MigrationRaceRoundMapper.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationRaceRoundMapper.cs
@@ -101,6 +101,7 @@ public sealed class MigrationRaceRoundMapper : IMigrationRaceRoundMapper
                 SourceRaceCode = start.RaceCode,
                 Season = mappedRace?.Season,
                 Round = mappedRace?.Round,
+                MappedCircuitId = mappedRace?.Race.Circuit?.CircuitId,
                 MappedRaceName = mappedRace?.Race.RaceName,
                 Warning = warning
             });

--- a/src/F1.DataSyncWorker/Services/MigrationRaceSelectionParser.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationRaceSelectionParser.cs
@@ -12,69 +12,6 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
     private const string SectionTypeRacePick = "RacePick";
     private const string SectionTypeHeader = "Header";
     private const string ActualSubject = "ACTUAL";
-    private static readonly Dictionary<string, string> RaceCodeAliasDictionary = new(StringComparer.OrdinalIgnoreCase)
-    {
-        ["AUS"] = "albert_park",
-        ["AUSTRALIA"] = "albert_park",
-        ["ALBERT PARK"] = "albert_park",
-        ["CHN"] = "shanghai",
-        ["CHINA"] = "shanghai",
-        ["SHANGHAI"] = "shanghai",
-        ["JPN"] = "suzuka",
-        ["JAPAN"] = "suzuka",
-        ["SUZUKA"] = "suzuka",
-        ["BAH"] = "bahrain",
-        ["BAHRAIN"] = "bahrain",
-        ["SAR"] = "jeddah",
-        ["SAUDI"] = "jeddah",
-        ["JEDDAH"] = "jeddah",
-        ["MIA"] = "miami",
-        ["MIAMI"] = "miami",
-        ["IMO"] = "imola",
-        ["IMOLA"] = "imola",
-        ["MON"] = "monaco",
-        ["MONACO"] = "monaco",
-        ["MONZA"] = "monza",
-        ["MNZ"] = "monza",
-        ["ITA"] = "monza",
-        ["ITALY"] = "monza",
-        ["BAR"] = "catalunya",
-        ["ESP"] = "catalunya",
-        ["SPAIN"] = "catalunya",
-        ["CAN"] = "villeneuve",
-        ["CANADA"] = "villeneuve",
-        ["AUSTRIA"] = "red_bull_ring",
-        ["AUT"] = "red_bull_ring",
-        ["RED BULL RING"] = "red_bull_ring",
-        ["GBR"] = "silverstone",
-        ["BRITAIN"] = "silverstone",
-        ["SILVERSTONE"] = "silverstone",
-        ["SPA"] = "spa",
-        ["BEL"] = "spa",
-        ["BELGIUM"] = "spa",
-        ["HUN"] = "hungaroring",
-        ["HUNGARY"] = "hungaroring",
-        ["NED"] = "zandvoort",
-        ["NETHERLANDS"] = "zandvoort",
-        ["BAK"] = "baku",
-        ["AZE"] = "baku",
-        ["AZERBAIJAN"] = "baku",
-        ["SIN"] = "marina_bay",
-        ["SINGAPORE"] = "marina_bay",
-        ["COTA"] = "americas",
-        ["USA"] = "americas",
-        ["UNITED STATES"] = "americas",
-        ["MEX"] = "rodriguez",
-        ["MEXICO"] = "rodriguez",
-        ["BRA"] = "interlagos",
-        ["BRAZIL"] = "interlagos",
-        ["LAS"] = "las_vegas",
-        ["VEGAS"] = "las_vegas",
-        ["QAT"] = "losail",
-        ["QATAR"] = "losail",
-        ["ABD"] = "yas_marina",
-        ["ABU DHABI"] = "yas_marina"
-    };
     private static readonly Dictionary<string, string?> TokenAliasDictionary = new(StringComparer.OrdinalIgnoreCase)
     {
         ["MAX"] = "VER",
@@ -280,7 +217,7 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
                 return false;
             }
 
-            raceCode = NormalizeRaceCode(humbugMatch.Groups[1].Value);
+            raceCode = RaceCodeNormalizer.NormalizeRaceCode(humbugMatch.Groups[1].Value);
             pickType = "DNF";
             currentRaceCode = raceCode;
             return true;
@@ -295,27 +232,16 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
                 return false;
             }
 
-            raceCode = NormalizeRaceCode(genericRaceMatch.Groups[1].Value);
+            raceCode = RaceCodeNormalizer.NormalizeRaceCode(genericRaceMatch.Groups[1].Value);
             pickType = "DNF";
             currentRaceCode = raceCode;
             return true;
         }
 
-        raceCode = NormalizeRaceCode(match.Groups[1].Value);
+        raceCode = RaceCodeNormalizer.NormalizeRaceCode(match.Groups[1].Value);
         pickType = match.Groups[2].Value.ToUpperInvariant();
         currentRaceCode = raceCode;
         return true;
-    }
-
-    private static string NormalizeRaceCode(string raceToken)
-    {
-        var upper = raceToken.Trim().ToUpperInvariant();
-        if (RaceCodeAliasDictionary.TryGetValue(upper, out var mapped))
-        {
-            return mapped;
-        }
-
-        return upper.Length <= 3 ? upper : upper[..3];
     }
 
     private static NormalizationResult NormalizeSelection(string? rawValue, string pickType)
@@ -424,10 +350,10 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
         return fields;
     }
 
-    [GeneratedRegex("^([A-Za-z]{3,})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    [GeneratedRegex("^([A-Za-z][A-Za-z\\s]{2,})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex RaceLabelRegex();
 
-    [GeneratedRegex("^([A-Za-z]{3,})-.+", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    [GeneratedRegex("^([A-Za-z][A-Za-z\\s]{2,})-.+", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex GenericRacePrefixRegex();
 
     [GeneratedRegex("^[A-Z]{3}$", RegexOptions.Compiled)]

--- a/src/F1.DataSyncWorker/Services/MigrationRaceSelectionParser.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationRaceSelectionParser.cs
@@ -12,6 +12,69 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
     private const string SectionTypeRacePick = "RacePick";
     private const string SectionTypeHeader = "Header";
     private const string ActualSubject = "ACTUAL";
+    private static readonly Dictionary<string, string> RaceCodeAliasDictionary = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["AUS"] = "albert_park",
+        ["AUSTRALIA"] = "albert_park",
+        ["ALBERT PARK"] = "albert_park",
+        ["CHN"] = "shanghai",
+        ["CHINA"] = "shanghai",
+        ["SHANGHAI"] = "shanghai",
+        ["JPN"] = "suzuka",
+        ["JAPAN"] = "suzuka",
+        ["SUZUKA"] = "suzuka",
+        ["BAH"] = "bahrain",
+        ["BAHRAIN"] = "bahrain",
+        ["SAR"] = "jeddah",
+        ["SAUDI"] = "jeddah",
+        ["JEDDAH"] = "jeddah",
+        ["MIA"] = "miami",
+        ["MIAMI"] = "miami",
+        ["IMO"] = "imola",
+        ["IMOLA"] = "imola",
+        ["MON"] = "monaco",
+        ["MONACO"] = "monaco",
+        ["MONZA"] = "monza",
+        ["MNZ"] = "monza",
+        ["ITA"] = "monza",
+        ["ITALY"] = "monza",
+        ["BAR"] = "catalunya",
+        ["ESP"] = "catalunya",
+        ["SPAIN"] = "catalunya",
+        ["CAN"] = "villeneuve",
+        ["CANADA"] = "villeneuve",
+        ["AUSTRIA"] = "red_bull_ring",
+        ["AUT"] = "red_bull_ring",
+        ["RED BULL RING"] = "red_bull_ring",
+        ["GBR"] = "silverstone",
+        ["BRITAIN"] = "silverstone",
+        ["SILVERSTONE"] = "silverstone",
+        ["SPA"] = "spa",
+        ["BEL"] = "spa",
+        ["BELGIUM"] = "spa",
+        ["HUN"] = "hungaroring",
+        ["HUNGARY"] = "hungaroring",
+        ["NED"] = "zandvoort",
+        ["NETHERLANDS"] = "zandvoort",
+        ["BAK"] = "baku",
+        ["AZE"] = "baku",
+        ["AZERBAIJAN"] = "baku",
+        ["SIN"] = "marina_bay",
+        ["SINGAPORE"] = "marina_bay",
+        ["COTA"] = "americas",
+        ["USA"] = "americas",
+        ["UNITED STATES"] = "americas",
+        ["MEX"] = "rodriguez",
+        ["MEXICO"] = "rodriguez",
+        ["BRA"] = "interlagos",
+        ["BRAZIL"] = "interlagos",
+        ["LAS"] = "las_vegas",
+        ["VEGAS"] = "las_vegas",
+        ["QAT"] = "losail",
+        ["QATAR"] = "losail",
+        ["ABD"] = "yas_marina",
+        ["ABU DHABI"] = "yas_marina"
+    };
     private static readonly Dictionary<string, string?> TokenAliasDictionary = new(StringComparer.OrdinalIgnoreCase)
     {
         ["MAX"] = "VER",
@@ -217,7 +280,7 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
                 return false;
             }
 
-            raceCode = humbugMatch.Groups[1].Value.ToUpperInvariant();
+            raceCode = NormalizeRaceCode(humbugMatch.Groups[1].Value);
             pickType = "DNF";
             currentRaceCode = raceCode;
             return true;
@@ -232,16 +295,27 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
                 return false;
             }
 
-            raceCode = genericRaceMatch.Groups[1].Value.ToUpperInvariant();
+            raceCode = NormalizeRaceCode(genericRaceMatch.Groups[1].Value);
             pickType = "DNF";
             currentRaceCode = raceCode;
             return true;
         }
 
-        raceCode = match.Groups[1].Value.ToUpperInvariant();
+        raceCode = NormalizeRaceCode(match.Groups[1].Value);
         pickType = match.Groups[2].Value.ToUpperInvariant();
         currentRaceCode = raceCode;
         return true;
+    }
+
+    private static string NormalizeRaceCode(string raceToken)
+    {
+        var upper = raceToken.Trim().ToUpperInvariant();
+        if (RaceCodeAliasDictionary.TryGetValue(upper, out var mapped))
+        {
+            return mapped;
+        }
+
+        return upper.Length <= 3 ? upper : upper[..3];
     }
 
     private static NormalizationResult NormalizeSelection(string? rawValue, string pickType)
@@ -350,10 +424,10 @@ public sealed partial class MigrationRaceSelectionParser : IMigrationRaceSelecti
         return fields;
     }
 
-    [GeneratedRegex("^([A-Za-z]{3})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    [GeneratedRegex("^([A-Za-z]{3,})-(1|2|3|DNF)$", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex RaceLabelRegex();
 
-    [GeneratedRegex("^([A-Za-z]{3})-.+", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
+    [GeneratedRegex("^([A-Za-z]{3,})-.+", RegexOptions.IgnoreCase | RegexOptions.Compiled)]
     private static partial Regex GenericRacePrefixRegex();
 
     [GeneratedRegex("^[A-Z]{3}$", RegexOptions.Compiled)]

--- a/src/F1.DataSyncWorker/Services/MigrationReconciliationService.cs
+++ b/src/F1.DataSyncWorker/Services/MigrationReconciliationService.cs
@@ -121,7 +121,7 @@ public sealed class MigrationReconciliationService : IMigrationReconciliationSer
                     CalculatedPoints = calculatedPoints,
                     DeltaPoints = delta,
                     ReasonCode = topReason,
-                    Explanation = $"{group.Key.Subject} {group.Key.RaceCode} imported {importedPoints}, calculated {calculatedPoints}, delta {delta}."
+                    Explanation = BuildRaceExplanation(group.Key.RaceCode, group.Key.Subject, importedPoints, calculatedPoints, delta, group)
                 };
             })
             .ToList();
@@ -233,6 +233,29 @@ public sealed class MigrationReconciliationService : IMigrationReconciliationSer
         }
 
         return $"{key.Subject} {key.RaceCode}-{key.PickType} imported {imported?.ToString() ?? "missing"}, calculated {calculated?.ToString() ?? "missing"}, delta {delta}. Reason: {reasonCode}.";
+    }
+
+    private static string BuildRaceExplanation(
+        string raceCode,
+        string subject,
+        int importedPoints,
+        int calculatedPoints,
+        int delta,
+        IEnumerable<MigrationImportPickDiffEntity> pickDiffs)
+    {
+        var contributors = pickDiffs
+            .Where(x => x.DeltaPoints != 0)
+            .OrderBy(x => PickTypeOrder(x.PickType))
+            .ThenBy(x => x.PickType, StringComparer.OrdinalIgnoreCase)
+            .Select(x => $"{raceCode}-{x.PickType} {x.ImportedPoints?.ToString() ?? "missing"}->{x.CalculatedPoints?.ToString() ?? "missing"} ({x.DeltaPoints}) [{x.ReasonCode}]")
+            .ToList();
+
+        var suffix = contributors.Count == 0
+            ? "No pick-level variance."
+            : $"Contributors: {string.Join("; ", contributors)}.";
+
+        var explanation = $"{subject} {raceCode} imported {importedPoints}, calculated {calculatedPoints}, delta {delta}. {suffix}";
+        return explanation.Length <= 1024 ? explanation : explanation[..1021] + "...";
     }
 
     private static int PickTypeOrder(string pickType)

--- a/src/F1.DataSyncWorker/Services/RaceCodeNormalizer.cs
+++ b/src/F1.DataSyncWorker/Services/RaceCodeNormalizer.cs
@@ -1,0 +1,84 @@
+namespace F1.DataSyncWorker.Services;
+
+internal static class RaceCodeNormalizer
+{
+    private static readonly Dictionary<string, string> RaceCodeAliasDictionary = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["AUS"] = "albert_park",
+        ["AUSTRALIA"] = "albert_park",
+        ["ALBERT PARK"] = "albert_park",
+        ["CHN"] = "shanghai",
+        ["CHINA"] = "shanghai",
+        ["SHANGHAI"] = "shanghai",
+        ["JPN"] = "suzuka",
+        ["JAPAN"] = "suzuka",
+        ["SUZUKA"] = "suzuka",
+        ["BAH"] = "bahrain",
+        ["BAHRAIN"] = "bahrain",
+        ["SAR"] = "jeddah",
+        ["SAUDI"] = "jeddah",
+        ["JEDDAH"] = "jeddah",
+        ["MIA"] = "miami",
+        ["MIAMI"] = "miami",
+        ["IMO"] = "imola",
+        ["IMOLA"] = "imola",
+        ["MON"] = "monaco",
+        ["MONACO"] = "monaco",
+        ["MONZA"] = "monza",
+        ["MNZ"] = "monza",
+        ["ITA"] = "monza",
+        ["ITALY"] = "monza",
+        ["BAR"] = "catalunya",
+        ["ESP"] = "catalunya",
+        ["SPAIN"] = "catalunya",
+        ["CAN"] = "villeneuve",
+        ["CANADA"] = "villeneuve",
+        ["AUSTRIA"] = "red_bull_ring",
+        ["AUT"] = "red_bull_ring",
+        ["RED BULL RING"] = "red_bull_ring",
+        ["GBR"] = "silverstone",
+        ["BRITAIN"] = "silverstone",
+        ["SILVERSTONE"] = "silverstone",
+        ["SPA"] = "spa",
+        ["BEL"] = "spa",
+        ["BELGIUM"] = "spa",
+        ["HUN"] = "hungaroring",
+        ["HUNGARY"] = "hungaroring",
+        ["NED"] = "zandvoort",
+        ["NETHERLANDS"] = "zandvoort",
+        ["BAK"] = "baku",
+        ["AZE"] = "baku",
+        ["AZERBAIJAN"] = "baku",
+        ["SIN"] = "marina_bay",
+        ["SINGAPORE"] = "marina_bay",
+        ["COTA"] = "americas",
+        ["USA"] = "americas",
+        ["UNITED STATES"] = "americas",
+        ["MEX"] = "rodriguez",
+        ["MEXICO"] = "rodriguez",
+        ["BRA"] = "interlagos",
+        ["BRAZIL"] = "interlagos",
+        ["LAS"] = "las_vegas",
+        ["VEGAS"] = "las_vegas",
+        ["QAT"] = "losail",
+        ["QATAR"] = "losail",
+        ["ABD"] = "yas_marina",
+        ["ABU DHABI"] = "yas_marina"
+    };
+
+    public static string NormalizeRaceCode(string raceToken)
+    {
+        var upper = NormalizeAliasLookupToken(raceToken);
+        if (RaceCodeAliasDictionary.TryGetValue(upper, out var mapped))
+        {
+            return mapped;
+        }
+
+        return upper.Length <= 3 ? upper : upper[..3];
+    }
+
+    private static string NormalizeAliasLookupToken(string rawValue)
+    {
+        return string.Join(" ", rawValue.Trim().ToUpperInvariant().Split((char[]?)null, StringSplitOptions.RemoveEmptyEntries));
+    }
+}

--- a/src/F1.Infrastructure/Data/Entities/MigrationImportRaceRoundMappingEntity.cs
+++ b/src/F1.Infrastructure/Data/Entities/MigrationImportRaceRoundMappingEntity.cs
@@ -9,6 +9,7 @@ public sealed class MigrationImportRaceRoundMappingEntity
     public string SourceRaceCode { get; set; } = string.Empty;
     public int? Season { get; set; }
     public int? Round { get; set; }
+    public string? MappedCircuitId { get; set; }
     public string? MappedRaceName { get; set; }
     public string? Warning { get; set; }
 }

--- a/src/F1.Infrastructure/Data/F1DbContext.cs
+++ b/src/F1.Infrastructure/Data/F1DbContext.cs
@@ -332,6 +332,7 @@ public class F1DbContext : DbContext
             entity.ToTable("MigrationImportRaceRoundMappings");
             entity.HasKey(x => x.Id);
             entity.Property(x => x.SourceRaceCode).HasMaxLength(16).IsRequired();
+            entity.Property(x => x.MappedCircuitId).HasMaxLength(64);
             entity.Property(x => x.MappedRaceName).HasMaxLength(256);
             entity.Property(x => x.Warning).HasMaxLength(512);
 

--- a/src/F1.Infrastructure/Migrations/20260706095718_AddMappedCircuitIdToRaceRoundMappings.Designer.cs
+++ b/src/F1.Infrastructure/Migrations/20260706095718_AddMappedCircuitIdToRaceRoundMappings.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using F1.Infrastructure.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace F1.Infrastructure.Migrations
 {
     [DbContext(typeof(F1DbContext))]
-    partial class F1DbContextModelSnapshot : ModelSnapshot
+    [Migration("20260706095718_AddMappedCircuitIdToRaceRoundMappings")]
+    partial class AddMappedCircuitIdToRaceRoundMappings
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/F1.Infrastructure/Migrations/20260706095718_AddMappedCircuitIdToRaceRoundMappings.cs
+++ b/src/F1.Infrastructure/Migrations/20260706095718_AddMappedCircuitIdToRaceRoundMappings.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace F1.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddMappedCircuitIdToRaceRoundMappings : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "MappedCircuitId",
+                table: "MigrationImportRaceRoundMappings",
+                type: "character varying(64)",
+                maxLength: 64,
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "MappedCircuitId",
+                table: "MigrationImportRaceRoundMappings");
+        }
+    }
+}

--- a/tests/F1.Infrastructure.Tests/Contracts/MigrationLegacyScoreImporterTests.cs
+++ b/tests/F1.Infrastructure.Tests/Contracts/MigrationLegacyScoreImporterTests.cs
@@ -156,6 +156,45 @@ public sealed class MigrationLegacyScoreImporterTests
     }
 
     [Fact]
+    public async Task ImportAndPersistAsync_WhenMultiWordRaceLabelsProvided_MapsToExpectedCircuitIds()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        dbContext.MigrationImportRawRows.AddRange(
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 1, SectionType = "Header", RawPayload = "Question,Philip,," },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 2, SectionType = "RacePoints", RawPayload = "ABU DHABI-1,10" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 3, SectionType = "RacePoints", RawPayload = "UNITED STATES-2,5" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 4, SectionType = "TotalsMeta", RawPayload = "Result,15" });
+
+        await dbContext.SaveChangesAsync();
+
+        var importer = new MigrationLegacyScoreImporter(new TestDbContextFactory(options));
+        var result = await importer.ImportAndPersistAsync(runId, CancellationToken.None);
+
+        Assert.Equal(2, result.LegacyPickScoreCount);
+
+        var legacyScores = await dbContext.MigrationImportLegacyPickScores
+            .Where(x => x.ImportRunId == runId)
+            .OrderBy(x => x.RowNumber)
+            .ToListAsync();
+
+        Assert.Equal("yas_marina", legacyScores[0].RaceCode);
+        Assert.Equal("americas", legacyScores[1].RaceCode);
+    }
+
+    [Fact]
     public async Task ImportAndPersistAsync_WhenRoundMappingsExist_UsesMappedCircuitIdsForAllLegacyRaceCodes()
     {
         var runId = Guid.NewGuid();

--- a/tests/F1.Infrastructure.Tests/Contracts/MigrationLegacyScoreImporterTests.cs
+++ b/tests/F1.Infrastructure.Tests/Contracts/MigrationLegacyScoreImporterTests.cs
@@ -32,10 +32,10 @@ public sealed class MigrationLegacyScoreImporterTests
             new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 5, SectionType = "TotalsMeta", RawPayload = "Result,590,550,410" });
 
         dbContext.MigrationImportCalculatedScores.AddRange(
-            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 2, RaceCode = "AUS", PickType = "1", Subject = "Philip", Points = 10, ReasonCode = "PODIUM_EXACT" },
-            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 3, RaceCode = "AUS", PickType = "2", Subject = "Philip", Points = 5, ReasonCode = "PODIUM_TOP3_WRONG_SLOT" },
-            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 4, RaceCode = "AUS", PickType = "DNF", Subject = "Philip", Points = 5, ReasonCode = "DNF_MATCH" },
-            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 2, RaceCode = "AUS", PickType = "1", Subject = "Andy", Points = 5, ReasonCode = "PODIUM_TOP3_WRONG_SLOT" });
+            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 2, RaceCode = "albert_park", PickType = "1", Subject = "Philip", Points = 10, ReasonCode = "PODIUM_EXACT" },
+            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 3, RaceCode = "albert_park", PickType = "2", Subject = "Philip", Points = 5, ReasonCode = "PODIUM_TOP3_WRONG_SLOT" },
+            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 4, RaceCode = "albert_park", PickType = "DNF", Subject = "Philip", Points = 5, ReasonCode = "DNF_MATCH" },
+            new MigrationImportCalculatedScoreEntity { ImportRunId = runId, RowNumber = 2, RaceCode = "albert_park", PickType = "1", Subject = "Andy", Points = 5, ReasonCode = "PODIUM_TOP3_WRONG_SLOT" });
 
         await dbContext.SaveChangesAsync();
 
@@ -53,8 +53,8 @@ public sealed class MigrationLegacyScoreImporterTests
             .ToListAsync();
 
         Assert.Equal(8, legacyScores.Count);
-        Assert.Contains(legacyScores, x => x.RaceCode == "AUS" && x.PickType == "DNF" && x.Subject == "Philip" && x.LegacyPoints == 5);
-        Assert.Contains(legacyScores, x => x.RaceCode == "AUS" && x.PickType == "1" && x.Subject == "Andy" && x.LegacyPoints == 5);
+        Assert.Contains(legacyScores, x => x.RaceCode == "albert_park" && x.PickType == "DNF" && x.Subject == "Philip" && x.LegacyPoints == 5);
+        Assert.Contains(legacyScores, x => x.RaceCode == "albert_park" && x.PickType == "1" && x.Subject == "Andy" && x.LegacyPoints == 5);
 
         var importedTotals = await dbContext.MigrationImportImportedTotals
             .Where(x => x.ImportRunId == runId)
@@ -114,6 +114,175 @@ public sealed class MigrationLegacyScoreImporterTests
 
         Assert.Equal("N/A", total.RawTotal);
         Assert.Null(total.ImportedTotalPoints);
+    }
+
+    [Fact]
+    public async Task ImportAndPersistAsync_WhenLongRaceLabelsProvided_MapsMonzaAndAustriaToJolpicaCircuitIds()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        dbContext.MigrationImportRawRows.AddRange(
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 1, SectionType = "Header", RawPayload = "Question,Philip,," },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 2, SectionType = "RacePoints", RawPayload = "MONZA-1,10" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 3, SectionType = "RacePoints", RawPayload = "AUSTRIA-2,5" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 4, SectionType = "TotalsMeta", RawPayload = "Result,15" });
+
+        await dbContext.SaveChangesAsync();
+
+        var importer = new MigrationLegacyScoreImporter(new TestDbContextFactory(options));
+        var result = await importer.ImportAndPersistAsync(runId, CancellationToken.None);
+
+        Assert.Equal(2, result.LegacyPickScoreCount);
+
+        var legacyScores = await dbContext.MigrationImportLegacyPickScores
+            .Where(x => x.ImportRunId == runId)
+            .OrderBy(x => x.RowNumber)
+            .ToListAsync();
+
+        Assert.Equal("monza", legacyScores[0].RaceCode);
+        Assert.Equal("red_bull_ring", legacyScores[1].RaceCode);
+    }
+
+    [Fact]
+    public async Task ImportAndPersistAsync_WhenRoundMappingsExist_UsesMappedCircuitIdsForAllLegacyRaceCodes()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        dbContext.MigrationImportRaceRoundMappings.AddRange(
+            new MigrationImportRaceRoundMappingEntity
+            {
+                ImportRunId = runId,
+                RaceSequence = 1,
+                SourceRowNumber = 2,
+                SourceRaceCode = "AUS",
+                Season = 2025,
+                Round = 1,
+                MappedCircuitId = "albert_park",
+                MappedRaceName = "Australian Grand Prix"
+            },
+            new MigrationImportRaceRoundMappingEntity
+            {
+                ImportRunId = runId,
+                RaceSequence = 2,
+                SourceRowNumber = 6,
+                SourceRaceCode = "CHN",
+                Season = 2025,
+                Round = 2,
+                MappedCircuitId = "shanghai",
+                MappedRaceName = "Chinese Grand Prix"
+            });
+
+        dbContext.MigrationImportRawRows.AddRange(
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 1, SectionType = "Header", RawPayload = "Question,Philip,," },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 2, SectionType = "RacePoints", RawPayload = "AUS-1,10" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 3, SectionType = "RacePoints", RawPayload = "AUS-2,5" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 4, SectionType = "RacePoints", RawPayload = "DNF,5" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 6, SectionType = "RacePoints", RawPayload = "CHN-1,10" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 7, SectionType = "RacePoints", RawPayload = "DNF,0" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 8, SectionType = "TotalsMeta", RawPayload = "Result,30" });
+
+        await dbContext.SaveChangesAsync();
+
+        var importer = new MigrationLegacyScoreImporter(new TestDbContextFactory(options));
+        var result = await importer.ImportAndPersistAsync(runId, CancellationToken.None);
+
+        Assert.Equal(5, result.LegacyPickScoreCount);
+
+        var legacyScores = await dbContext.MigrationImportLegacyPickScores
+            .Where(x => x.ImportRunId == runId)
+            .OrderBy(x => x.RowNumber)
+            .ToListAsync();
+
+        Assert.Equal("albert_park", legacyScores[0].RaceCode);
+        Assert.Equal("albert_park", legacyScores[1].RaceCode);
+        Assert.Equal("albert_park", legacyScores[2].RaceCode);
+        Assert.Equal("shanghai", legacyScores[3].RaceCode);
+        Assert.Equal("shanghai", legacyScores[4].RaceCode);
+    }
+
+    [Fact]
+    public async Task ImportAndPersistAsync_WhenSameSourceRaceCodeRepeatsAcrossBlocks_UsesRowRangeCircuitMapping()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        dbContext.MigrationImportRaceRoundMappings.AddRange(
+            new MigrationImportRaceRoundMappingEntity
+            {
+                ImportRunId = runId,
+                RaceSequence = 1,
+                SourceRowNumber = 2,
+                SourceRaceCode = "AUS",
+                MappedCircuitId = "albert_park"
+            },
+            new MigrationImportRaceRoundMappingEntity
+            {
+                ImportRunId = runId,
+                RaceSequence = 2,
+                SourceRowNumber = 6,
+                SourceRaceCode = "AUS",
+                MappedCircuitId = "red_bull_ring"
+            });
+
+        dbContext.MigrationImportRawRows.AddRange(
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 1, SectionType = "Header", RawPayload = "Question,Philip,," },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 2, SectionType = "RacePoints", RawPayload = "AUS-1,10" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 3, SectionType = "RacePoints", RawPayload = "AUS-2,5" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 4, SectionType = "RacePoints", RawPayload = "DNF,0" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 6, SectionType = "RacePoints", RawPayload = "AUS-1,10" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 7, SectionType = "RacePoints", RawPayload = "DNF,5" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 8, SectionType = "TotalsMeta", RawPayload = "Result,30" });
+
+        await dbContext.SaveChangesAsync();
+
+        var importer = new MigrationLegacyScoreImporter(new TestDbContextFactory(options));
+        await importer.ImportAndPersistAsync(runId, CancellationToken.None);
+
+        var legacyScores = await dbContext.MigrationImportLegacyPickScores
+            .Where(x => x.ImportRunId == runId)
+            .OrderBy(x => x.RowNumber)
+            .ToListAsync();
+
+        Assert.Equal("albert_park", legacyScores[0].RaceCode);
+        Assert.Equal("albert_park", legacyScores[1].RaceCode);
+        Assert.Equal("albert_park", legacyScores[2].RaceCode);
+        Assert.Equal("red_bull_ring", legacyScores[3].RaceCode);
+        Assert.Equal("red_bull_ring", legacyScores[4].RaceCode);
     }
 
     private static DbContextOptions<F1DbContext> CreateOptions()

--- a/tests/F1.Infrastructure.Tests/Contracts/MigrationRaceRoundMapperTests.cs
+++ b/tests/F1.Infrastructure.Tests/Contracts/MigrationRaceRoundMapperTests.cs
@@ -55,6 +55,9 @@ public sealed class MigrationRaceRoundMapperTests
         Assert.Equal(1, mappings[0].Round);
         Assert.Equal(2, mappings[1].Round);
         Assert.Equal(3, mappings[2].Round);
+        Assert.Equal("albert_park", mappings[0].MappedCircuitId);
+        Assert.Equal("monaco", mappings[1].MappedCircuitId);
+        Assert.Equal("monza", mappings[2].MappedCircuitId);
         Assert.Contains("sequence-based mapping applied", mappings[2].Warning ?? string.Empty, StringComparison.OrdinalIgnoreCase);
 
         var snapshots = await dbContext.MigrationImportJolpicaRaceSnapshots
@@ -111,6 +114,54 @@ public sealed class MigrationRaceRoundMapperTests
         Assert.Contains("No Jolpica race available", lastMapping.Warning ?? string.Empty, StringComparison.OrdinalIgnoreCase);
     }
 
+    [Fact]
+    public async Task MapAndPersistAsync_WhenRaceCodesAreSimilar_AusAndAut_MapBySequenceWithoutAmbiguityWarning()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        dbContext.MigrationImportRaceSelections.AddRange(
+            CreateSelection(runId, 10, "AUS", "1", "Philip"),
+            CreateSelection(runId, 20, "AUT", "1", "Philip"));
+
+        await dbContext.SaveChangesAsync();
+
+        var mapper = new MigrationRaceRoundMapper(
+            new TestDbContextFactory(options),
+            new StubJolpicaClient(),
+            Options.Create(new DataSyncOptions { HttpRetryCount = 0, HttpRetryDelayMs = 1 }),
+            Options.Create(new MigrationImportOptions { Season = 2025 }));
+
+        var result = await mapper.MapAndPersistAsync(runId, CancellationToken.None);
+
+        Assert.Equal(2, result.MappingCount);
+        Assert.Equal(0, result.WarningCount);
+
+        var mappings = await dbContext.MigrationImportRaceRoundMappings
+            .Where(x => x.ImportRunId == runId)
+            .OrderBy(x => x.RaceSequence)
+            .ToListAsync();
+
+        Assert.Equal("AUS", mappings[0].SourceRaceCode);
+        Assert.Equal(1, mappings[0].Round);
+        Assert.Equal("albert_park", mappings[0].MappedCircuitId);
+        Assert.Equal("AUT", mappings[1].SourceRaceCode);
+        Assert.Equal(2, mappings[1].Round);
+        Assert.Equal("monaco", mappings[1].MappedCircuitId);
+        Assert.All(mappings, x => Assert.True(string.IsNullOrWhiteSpace(x.Warning)));
+    }
+
     private static MigrationImportRaceSelectionEntity CreateSelection(Guid runId, int rowNumber, string raceCode, string pickType, string subject)
     {
         return new MigrationImportRaceSelectionEntity
@@ -164,9 +215,9 @@ public sealed class MigrationRaceRoundMapperTests
         {
             IReadOnlyList<JolpicaRaceDto> races =
             [
-                new() { Season = "2025", Round = "1", RaceName = "Australian Grand Prix", Date = "2025-03-16", Time = "05:00:00Z", Circuit = new JolpicaCircuitDto { CircuitName = "Albert Park" } },
-                new() { Season = "2025", Round = "2", RaceName = "Monaco Grand Prix", Date = "2025-05-25", Time = "13:00:00Z", Circuit = new JolpicaCircuitDto { CircuitName = "Monaco" } },
-                new() { Season = "2025", Round = "3", RaceName = "Italian Grand Prix", Date = "2025-09-07", Time = "13:00:00Z", Circuit = new JolpicaCircuitDto { CircuitName = "Monza" } }
+                new() { Season = "2025", Round = "1", RaceName = "Australian Grand Prix", Date = "2025-03-16", Time = "05:00:00Z", Circuit = new JolpicaCircuitDto { CircuitId = "albert_park", CircuitName = "Albert Park" } },
+                new() { Season = "2025", Round = "2", RaceName = "Monaco Grand Prix", Date = "2025-05-25", Time = "13:00:00Z", Circuit = new JolpicaCircuitDto { CircuitId = "monaco", CircuitName = "Monaco" } },
+                new() { Season = "2025", Round = "3", RaceName = "Italian Grand Prix", Date = "2025-09-07", Time = "13:00:00Z", Circuit = new JolpicaCircuitDto { CircuitId = "monza", CircuitName = "Monza" } }
             ];
 
             return Task.FromResult(races);

--- a/tests/F1.Infrastructure.Tests/Contracts/MigrationRaceSelectionParserTests.cs
+++ b/tests/F1.Infrastructure.Tests/Contracts/MigrationRaceSelectionParserTests.cs
@@ -46,7 +46,7 @@ public sealed class MigrationRaceSelectionParserTests
         Assert.Equal(8, selections.Count);
 
         var ausWinner = selections.Single(x => x.RowNumber == 2 && x.Subject == "Philip" && !x.IsActualOutcome);
-        Assert.Equal("AUS", ausWinner.RaceCode);
+        Assert.Equal("albert_park", ausWinner.RaceCode);
         Assert.Equal("1", ausWinner.PickType);
         Assert.Equal("VER", ausWinner.NormalizedValue);
 
@@ -94,7 +94,7 @@ public sealed class MigrationRaceSelectionParserTests
         var lRowActual = await dbContext.MigrationImportRaceSelections
             .SingleAsync(x => x.ImportRunId == runId && x.RowNumber == 3 && x.Subject == "ACTUAL");
 
-        Assert.Equal("AUS", lRowActual.RaceCode);
+        Assert.Equal("albert_park", lRowActual.RaceCode);
         Assert.Equal("2", lRowActual.PickType);
         Assert.Equal("NOR", lRowActual.NormalizedValue);
         Assert.True(lRowActual.IsActualOutcome);
@@ -222,7 +222,7 @@ public sealed class MigrationRaceSelectionParserTests
         Assert.Equal("verstappen", unresolved[1].RawToken);
         Assert.All(unresolved, token =>
         {
-            Assert.Equal("AUS", token.RaceCode);
+            Assert.Equal("albert_park", token.RaceCode);
             Assert.Equal("1", token.PickType);
             Assert.Equal(2, token.RowNumber);
         });
@@ -310,6 +310,124 @@ public sealed class MigrationRaceSelectionParserTests
 
         Assert.Equal("LEC", participantPick.NormalizedValue);
         Assert.Empty(await dbContext.MigrationImportUnresolvedTokens.Where(x => x.ImportRunId == runId).ToListAsync());
+    }
+
+    [Fact]
+    public async Task ParseAndPersistAsync_WhenLongRaceLabelsProvided_MapsMonzaAndAustriaToJolpicaCircuitIds()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        dbContext.MigrationImportRawRows.AddRange(
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 1, SectionType = "Header", RawPayload = "Question,Philip,," },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 2, SectionType = "RacePick", RawPayload = "MONZA-1,VER,VER" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 3, SectionType = "RacePick", RawPayload = "AUSTRIA-2,NOR,NOR" });
+
+        await dbContext.SaveChangesAsync();
+
+        var parser = new MigrationRaceSelectionParser(new TestDbContextFactory(options));
+        var parseResult = await parser.ParseAndPersistAsync(runId, CancellationToken.None);
+
+        Assert.Equal(4, parseResult.SelectionCount);
+        Assert.Equal(0, parseResult.UnresolvedTokenCount);
+
+        var monzaPick = await dbContext.MigrationImportRaceSelections
+            .SingleAsync(x => x.ImportRunId == runId && x.RowNumber == 2 && x.Subject == "Philip");
+        Assert.Equal("monza", monzaPick.RaceCode);
+
+        var austriaPick = await dbContext.MigrationImportRaceSelections
+            .SingleAsync(x => x.ImportRunId == runId && x.RowNumber == 3 && x.Subject == "Philip");
+        Assert.Equal("red_bull_ring", austriaPick.RaceCode);
+    }
+
+    [Fact]
+    public async Task ParseAndPersistAsync_WhenSeasonRaceCodesUsed_MapsAllToJolpicaCircuitIds()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        var raceLabels = new (string Label, string ExpectedCircuitId)[]
+        {
+            ("AUS-1", "albert_park"),
+            ("CHN-1", "shanghai"),
+            ("JPN-1", "suzuka"),
+            ("BAH-1", "bahrain"),
+            ("SAR-1", "jeddah"),
+            ("MIA-1", "miami"),
+            ("IMO-1", "imola"),
+            ("MON-1", "monaco"),
+            ("BAR-1", "catalunya"),
+            ("CAN-1", "villeneuve"),
+            ("AUT-1", "red_bull_ring"),
+            ("GBR-1", "silverstone"),
+            ("SPA-1", "spa"),
+            ("HUN-1", "hungaroring"),
+            ("NED-1", "zandvoort"),
+            ("BAK-1", "baku"),
+            ("SIN-1", "marina_bay"),
+            ("COTA-1", "americas"),
+            ("MEX-1", "rodriguez"),
+            ("BRA-1", "interlagos"),
+            ("LAS-1", "las_vegas"),
+            ("QAT-1", "losail"),
+            ("ABD-1", "yas_marina")
+        };
+
+        var rows = new List<MigrationImportRawRowEntity>
+        {
+            new() { ImportRunId = runId, RowNumber = 1, SectionType = "Header", RawPayload = "Question,Philip,," }
+        };
+
+        for (var index = 0; index < raceLabels.Length; index++)
+        {
+            rows.Add(new MigrationImportRawRowEntity
+            {
+                ImportRunId = runId,
+                RowNumber = index + 2,
+                SectionType = "RacePick",
+                RawPayload = $"{raceLabels[index].Label},VER,VER"
+            });
+        }
+
+        dbContext.MigrationImportRawRows.AddRange(rows);
+        await dbContext.SaveChangesAsync();
+
+        var parser = new MigrationRaceSelectionParser(new TestDbContextFactory(options));
+        var parseResult = await parser.ParseAndPersistAsync(runId, CancellationToken.None);
+
+        Assert.Equal(raceLabels.Length * 2, parseResult.SelectionCount);
+        Assert.Equal(0, parseResult.UnresolvedTokenCount);
+
+        for (var index = 0; index < raceLabels.Length; index++)
+        {
+            var rowNumber = index + 2;
+            var selection = await dbContext.MigrationImportRaceSelections
+                .SingleAsync(x => x.ImportRunId == runId && x.RowNumber == rowNumber && x.Subject == "Philip");
+
+            Assert.Equal(raceLabels[index].ExpectedCircuitId, selection.RaceCode);
+        }
     }
 
     private static DbContextOptions<F1DbContext> CreateOptions()

--- a/tests/F1.Infrastructure.Tests/Contracts/MigrationRaceSelectionParserTests.cs
+++ b/tests/F1.Infrastructure.Tests/Contracts/MigrationRaceSelectionParserTests.cs
@@ -352,6 +352,45 @@ public sealed class MigrationRaceSelectionParserTests
     }
 
     [Fact]
+    public async Task ParseAndPersistAsync_WhenMultiWordRaceLabelsProvided_MapsToExpectedCircuitIds()
+    {
+        var runId = Guid.NewGuid();
+        var options = CreateOptions();
+        await using var dbContext = new F1DbContext(options);
+
+        dbContext.MigrationImportRuns.Add(new MigrationImportRunEntity
+        {
+            Id = runId,
+            SourceFilePath = "test.csv",
+            SourceFileChecksum = "abc",
+            IsDryRun = true,
+            Status = "Started",
+            StartedAtUtc = DateTime.UtcNow
+        });
+
+        dbContext.MigrationImportRawRows.AddRange(
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 1, SectionType = "Header", RawPayload = "Question,Philip,," },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 2, SectionType = "RacePick", RawPayload = "ABU DHABI-1,VER,VER" },
+            new MigrationImportRawRowEntity { ImportRunId = runId, RowNumber = 3, SectionType = "RacePick", RawPayload = "UNITED STATES-2,NOR,NOR" });
+
+        await dbContext.SaveChangesAsync();
+
+        var parser = new MigrationRaceSelectionParser(new TestDbContextFactory(options));
+        var parseResult = await parser.ParseAndPersistAsync(runId, CancellationToken.None);
+
+        Assert.Equal(4, parseResult.SelectionCount);
+        Assert.Equal(0, parseResult.UnresolvedTokenCount);
+
+        var abuDhabiPick = await dbContext.MigrationImportRaceSelections
+            .SingleAsync(x => x.ImportRunId == runId && x.RowNumber == 2 && x.Subject == "Philip");
+        Assert.Equal("yas_marina", abuDhabiPick.RaceCode);
+
+        var unitedStatesPick = await dbContext.MigrationImportRaceSelections
+            .SingleAsync(x => x.ImportRunId == runId && x.RowNumber == 3 && x.Subject == "Philip");
+        Assert.Equal("americas", unitedStatesPick.RaceCode);
+    }
+
+    [Fact]
     public async Task ParseAndPersistAsync_WhenSeasonRaceCodesUsed_MapsAllToJolpicaCircuitIds()
     {
         var runId = Guid.NewGuid();

--- a/tests/F1.Infrastructure.Tests/Contracts/MigrationReconciliationServiceTests.cs
+++ b/tests/F1.Infrastructure.Tests/Contracts/MigrationReconciliationServiceTests.cs
@@ -76,6 +76,16 @@ public sealed class MigrationReconciliationServiceTests
         var nonZero = pickDiffs.Where(x => x.DeltaPoints != 0).ToList();
         Assert.NotEmpty(nonZero);
         Assert.All(nonZero, x => Assert.False(string.IsNullOrWhiteSpace(x.Explanation)));
+
+        var philipAusRaceDiff = await dbContext.MigrationImportRaceDiffs
+            .SingleAsync(x => x.ImportRunId == runId && x.RaceCode == "AUS" && x.Subject == "Philip");
+        Assert.Contains("Contributors:", philipAusRaceDiff.Explanation);
+        Assert.Contains("AUS-1 10->5 (-5)", philipAusRaceDiff.Explanation);
+        Assert.Contains("AUS-DNF 5->0 (-5)", philipAusRaceDiff.Explanation);
+
+        var andyAusRaceDiff = await dbContext.MigrationImportRaceDiffs
+            .SingleAsync(x => x.ImportRunId == runId && x.RaceCode == "AUS" && x.Subject == "Andy");
+        Assert.Contains("AUS-2 5->10 (5)", andyAusRaceDiff.Explanation);
     }
 
     [Fact]

--- a/tests/F1.Infrastructure.Tests/Relational/MigrationImportRunServiceTests.cs
+++ b/tests/F1.Infrastructure.Tests/Relational/MigrationImportRunServiceTests.cs
@@ -262,6 +262,83 @@ public sealed class MigrationImportRunServiceTests
         }
     }
 
+    [Fact]
+    public async Task RunOnceAsync_WhenWriteModeEnabled_RewritesSelectionRaceCodesToMappedCircuitIds()
+    {
+        await using var setupContext = CreateContext();
+        await setupContext.Database.EnsureDeletedAsync();
+        await setupContext.Database.EnsureCreatedAsync();
+
+        var sourceFilePath = await CreateTempCsvAsync(
+            "Question,Philip,,\n" +
+            "AUS-1,VER,VER\n" +
+            "DNF,NONE,\n" +
+            "CHN-1,NOR,NOR\n" +
+            "DNF,NONE,\n" +
+            "AUS-1,10,10\n" +
+            "DNF,5,5\n" +
+            "CHN-1,10,10\n" +
+            "DNF,0,0\n" +
+            "Result,25\n");
+
+        try
+        {
+            var dbFactory = new TestDbContextFactory(_fixture.ConnectionString);
+            var runService = new MigrationImportRunService(dbFactory);
+
+            var orchestrator = new MigrationImportOrchestrator(
+                NullLogger<MigrationImportOrchestrator>.Instance,
+                runService,
+                new MigrationImportRowClassifier(),
+                new MigrationRaceSelectionParser(dbFactory),
+                new MigrationRaceRoundMapper(
+                    dbFactory,
+                    new TrackingJolpicaClient(),
+                    Options.Create(new DataSyncOptions { HttpRetryCount = 0, HttpRetryDelayMs = 1 }),
+                    Options.Create(new MigrationImportOptions { Season = 2025 })),
+                new MigrationScoreRecalculator(dbFactory),
+                new MigrationLegacyScoreImporter(dbFactory),
+                new MigrationReconciliationService(dbFactory),
+                dbFactory,
+                Options.Create(new DataSyncOptions { AutoMigrate = false }),
+                Options.Create(new MigrationImportOptions
+                {
+                    Enabled = true,
+                    SourceFilePath = sourceFilePath,
+                    DryRun = false,
+                    Season = 2025
+                }));
+
+            await orchestrator.RunOnceAsync(CancellationToken.None);
+
+            await using var verificationContext = CreateContext();
+            var run = await verificationContext.MigrationImportRuns.AsNoTracking().SingleAsync();
+            Assert.Equal("Completed", run.Status);
+
+            var participantSelections = await verificationContext.MigrationImportRaceSelections
+                .Where(x => x.ImportRunId == run.Id && x.Subject == "Philip")
+                .OrderBy(x => x.RowNumber)
+                .ToListAsync();
+
+            Assert.Equal("albert_park", participantSelections[0].RaceCode);
+            Assert.Equal("albert_park", participantSelections[1].RaceCode);
+            Assert.Equal("shanghai", participantSelections[2].RaceCode);
+            Assert.Equal("shanghai", participantSelections[3].RaceCode);
+
+            var legacyScores = await verificationContext.MigrationImportLegacyPickScores
+                .Where(x => x.ImportRunId == run.Id)
+                .OrderBy(x => x.RowNumber)
+                .ToListAsync();
+
+            Assert.Contains(legacyScores, x => x.RaceCode == "albert_park");
+            Assert.Contains(legacyScores, x => x.RaceCode == "shanghai");
+        }
+        finally
+        {
+            File.Delete(sourceFilePath);
+        }
+    }
+
     private static async Task<string> CreateTempCsvAsync(string content)
     {
         var tempPath = Path.Combine(Path.GetTempPath(), $"f1-migration-{Guid.NewGuid():N}.csv");
@@ -315,8 +392,8 @@ public sealed class MigrationImportRunServiceTests
 
             IReadOnlyList<JolpicaRaceDto> races =
             [
-                new() { Season = "2025", Round = "1", RaceName = "Australian Grand Prix", Date = "2025-03-16", Time = "05:00:00Z" },
-                new() { Season = "2025", Round = "2", RaceName = "Chinese Grand Prix", Date = "2025-03-23", Time = "07:00:00Z" }
+                new() { Season = "2025", Round = "1", RaceName = "Australian Grand Prix", Date = "2025-03-16", Time = "05:00:00Z", Circuit = new JolpicaCircuitDto { CircuitId = "albert_park", CircuitName = "Albert Park Grand Prix Circuit" } },
+                new() { Season = "2025", Round = "2", RaceName = "Chinese Grand Prix", Date = "2025-03-23", Time = "07:00:00Z", Circuit = new JolpicaCircuitDto { CircuitId = "shanghai", CircuitName = "Shanghai International Circuit" } }
             ];
             return Task.FromResult(races);
         }


### PR DESCRIPTION
…ll mapped race blocks

#239 rewrite selection and legacy RaceCode fields using sequence-based mapped circuitId to resolve Monaco Monza ambiguity #239 expand import race normalization to map all used season track codes to Jolpica circuitId values #239 harden ambiguous reused race-code handling via sequence-mapped circuitId rewrite for selections and legacy scores